### PR TITLE
Use Proxy from purescript-proxy package.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "purescript-arrays" : "*",
     "purescript-foldable-traversable": "*",
     "purescript-math": "*",
-    "purescript-generics":"*",
+    "purescript-proxy": "*",
     "purescript-extensions" : "*"
   },
   "devDependencies": {

--- a/src/Data/TypeNat.purs
+++ b/src/Data/TypeNat.purs
@@ -13,7 +13,7 @@
 module Data.TypeNat where
 
 import Prelude
-import Data.Generic (anyProxy, Proxy())
+import Type.Proxy
 
 data Zero
 data One

--- a/src/Data/Vector.purs
+++ b/src/Data/Vector.purs
@@ -21,18 +21,18 @@ import Data.Foldable
 import Data.TypeNat
 import Control.Apply
 import Math
-import Data.Generic (anyProxy, Proxy())
+import Type.Proxy
 import Extensions (fail)
 
 newtype Vec s a = Vec (Array a)
 
 fill :: forall s a. (Num a, Sized s) => a -> Vec s a
-fill a = Vec (replicate (sized (anyProxy :: Proxy s)) a)
+fill a = Vec (replicate (sized (Proxy :: Proxy s)) a)
 
 fromArray :: forall s a. (Sized s) => Array a -> Vec s a
 fromArray l =
   let res = Vec l
-  in case sized (anyProxy :: Proxy s) of
+  in case sized (Proxy :: Proxy s) of
         i | i == length l -> res
           | otherwise     -> fail "Vector>>fromArray: wrong array length!"
 


### PR DESCRIPTION
Proxy has been removed from purescript-generics in version 0.7.0, where it has been replaced with the purescript-proxy module.
