### PR TITLE
Removed Extensions Dependency

### DIFF
--- a/benchmarks/Main.purs
+++ b/benchmarks/Main.purs
@@ -9,7 +9,6 @@ import qualified Data.Vector3 as V
 import qualified Data.Vector as V
 import Benchotron.Core
 import Benchotron.UI.Console
-import Extensions (mapM)
 
 vecSum :: forall e. Benchmark (random :: RANDOM | e)
 vecSum = mkBenchmark
@@ -43,6 +42,6 @@ randomVec3 = do
     return (V.vec3' [x,y,z])
 
 randomArray :: forall e a. Eff (random :: RANDOM | e) a -> Int -> Eff (random :: RANDOM | e) (Array a)
-randomArray generator size = mapM (\ _ -> generator) (0..(size-1))
+randomArray generator size = sequence $ map (\ _ -> generator) (0..(size-1))
 
 main = runSuite [vecSum, vecSumPrim]

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "purescript-arrays": "^4.2.0",
     "purescript-foldable-traversable": "^3.6.1",
     "purescript-math": "^2.1.0",
-    "purescript-extensions": "^2.2.0",
     "purescript-proxy": "^2.1.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,5 @@
     "purescript-random": "^3.0.0"
   },
   "resolutions": {
-    "purescript-extensions": "^2.2.0"
   }
 }

--- a/src/Data/Vector.purs
+++ b/src/Data/Vector.purs
@@ -17,11 +17,12 @@ import Prelude
 import Data.Array (zipWith, length)
 import Data.Monoid (mempty)
 import Data.Foldable (class Foldable, foldl, foldr)
+import Data.Unfoldable (replicate)
 import Data.TypeNat (class Sized, sized)
+import Partial.Unsafe (unsafeCrashWith)
 import Control.Apply (lift2)
 import Math (sqrt)
 import Type.Proxy (Proxy(..))
-import Extensions (fail, replicate)
 
 newtype Vec s a = Vec (Array a)
 
@@ -33,7 +34,7 @@ fromArray l =
   let res = Vec l
   in case sized (Proxy :: Proxy s) of
         i | i == length l -> res
-          | otherwise     -> fail "Vector>>fromArray: wrong array length!"
+        | otherwise     -> unsafeCrashWith "Vector>>fromArray: wrong array length!"
 
 toArray :: forall s a. Vec s a -> Array a
 toArray (Vec a) = a

--- a/src/Data/Vector2.purs
+++ b/src/Data/Vector2.purs
@@ -18,8 +18,7 @@ import Data.Vector (Vec(Vec))
 import Data.TypeNat (Two)
 import Data.Array (insertAt, length, unsafeIndex)
 import Data.Maybe(fromJust)
-import Extensions (fail)
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 
 type Vec2 = Vec Two
 
@@ -28,7 +27,7 @@ vec2 x y = Vec [x,y]
 
 vec2' :: forall a. Array a -> Vec2 a
 vec2' array | length array == 2 = Vec array
-            | otherwise         = fail "Vector2>>vec2': wrong array length!"
+            | otherwise         = unsafeCrashWith "Vector2>>vec2': wrong array length!"
 
 i2 :: Vec2 Number
 i2 = Vec [1.0,0.0]

--- a/src/Data/Vector3.purs
+++ b/src/Data/Vector3.purs
@@ -18,8 +18,7 @@ import Data.Vector (Vec(Vec))
 import Data.TypeNat (Three)
 import Data.Array (insertAt, length, unsafeIndex)
 import Data.Maybe (fromJust)
-import Extensions (fail)
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 
 
 type Vec3 = Vec Three
@@ -29,7 +28,7 @@ vec3 x y z = Vec [x,y,z]
 
 vec3' :: forall a. Array a -> Vec3 a
 vec3' array | length array == 3 = Vec array
-            | otherwise         = fail "Vector3>>vec3': wrong array length!"
+            | otherwise         = unsafeCrashWith "Vector3>>vec3': wrong array length!"
 
 i3 :: Vec3 Number
 i3 = Vec [1.0,0.0,0.0]
@@ -59,4 +58,4 @@ set3Z n (Vec v) = Vec (unsafePartial $ fromJust (insertAt 2 n v))
 -- | The cross product of a and b
 cross :: forall a. (EuclideanRing a) => Vec3 a -> Vec3 a -> Vec3 a
 cross (Vec [x1,y1,z1]) (Vec [x2,y2,z2]) = Vec [y1*z2 - z1*y2, z1*x2 - x1*z2, x1*y2 - y1*x2]
-cross _ _ = fail "Vector3>>cross: impossible!"
+cross _ _ = unsafeCrashWith "Vector3>>cross: impossible!"

--- a/src/Data/Vector4.purs
+++ b/src/Data/Vector4.purs
@@ -18,8 +18,7 @@ import Data.Vector (Vec(Vec))
 import Data.TypeNat (Four)
 import Data.Array (insertAt, length, unsafeIndex)
 import Data.Maybe (fromJust)
-import Extensions (fail)
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 
 type Vec4 = Vec Four
 
@@ -28,7 +27,7 @@ vec4 x y z u = Vec [x,y,z,u]
 
 vec4' :: forall a. Array a -> Vec4 a
 vec4' array | length array == 4 = Vec array
-            | otherwise         = fail "Vector4>>vec4': wrong array length!"
+            | otherwise         = unsafeCrashWith "Vector4>>vec4': wrong array length!"
 
 i4 :: Vec4 Number
 i4 = Vec [1.0,0.0,0.0,0.0]


### PR DESCRIPTION
Hi Jutaro
Trying to get gl/vector/matrix libraries into psc-package.
I found Extensions to be a burden in this work as fail is (now) easily replaced with unsafeCrashWith, and mapM was one line.  So I have made those substitutions here.

It seems youre not attending these libraries anymore so I may fork hard soon but wanted to put a note here still.  In fact, no license is mentioned here, so if you could just do one thing, could you please specify your licensing interests!!

Thanks!
Alex